### PR TITLE
feat: use OAuth resource server to protect private apis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/securingweb/ApiController.java
+++ b/src/main/java/com/example/securingweb/ApiController.java
@@ -1,0 +1,23 @@
+package com.example.securingweb;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@CrossOrigin(origins = "*")
+@RestController
+@RequestMapping("/api")
+public class ApiController {
+
+  @GetMapping("/protected")
+  public ResponseEntity<Map<String, Boolean>> testApi() {
+    Map<String, Boolean> response = new HashMap<>();
+    response.put("success", true);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/example/securingweb/AudienceValidator.java
+++ b/src/main/java/com/example/securingweb/AudienceValidator.java
@@ -1,0 +1,24 @@
+package com.example.securingweb;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class AudienceValidator implements OAuth2TokenValidator<Jwt> {
+  private final OAuth2Error oAuth2Error = new OAuth2Error("invalid_token", "Required audience not found", null);
+  private final String audience;
+
+  public AudienceValidator(String audience) {
+    this.audience = audience;
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(Jwt jwt) {
+    if (jwt.getAudience().contains(audience)) {
+      return OAuth2TokenValidatorResult.success();
+    }
+
+    return OAuth2TokenValidatorResult.failure(oAuth2Error);
+  }
+}

--- a/src/main/java/com/example/securingweb/UserController.java
+++ b/src/main/java/com/example/securingweb/UserController.java
@@ -4,6 +4,7 @@ import java.security.Principal;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,9 @@ import com.nimbusds.jose.proc.SecurityContext;
 @Controller
 @RequestMapping("/user")
 public class UserController {
+  @Value("${spring.security.oauth2.resourceserver.jwt.audiences}")
+  private String audience;
+
   @GetMapping
   public String user(Model model, Principal principal) {
     if (principal instanceof OAuth2AuthenticationToken) {
@@ -54,7 +58,7 @@ public class UserController {
   public String getTokens(Model model, OAuth2AuthenticationToken principal) {
 
     // Get new access token using refresh token for a given resource
-    getNewAccessToken(principal, "http://localhost:3001/api/test");
+    getNewAccessToken(principal, audience);
 
     OAuth2AccessToken accessToken = getAccessToken(principal);
     OAuth2RefreshToken refreshToken = getRefreshToken(principal);

--- a/src/main/java/com/example/securingweb/WebSecurityConfig.java
+++ b/src/main/java/com/example/securingweb/WebSecurityConfig.java
@@ -3,8 +3,11 @@ package com.example.securingweb;
 import java.util.function.Consumer;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
@@ -12,15 +15,33 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.DefaultSecurityFilterChain;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
+import com.nimbusds.jose.proc.SecurityContext;
 
 @Configuration
 @EnableWebSecurity
 
 public class WebSecurityConfig {
+  @Value("${spring.security.oauth2.resourceserver.jwt.audiences}")
+  private String audience;
+
+  @Value("${spring.security.oauth2.client.provider.logto.jwk-set-uri}")
+  private String jwksUri;
+
+  @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+  private String issuer;
+
   @Autowired
   private ClientRegistrationRepository clientRegistrationRepository;
 
@@ -32,11 +53,43 @@ public class WebSecurityConfig {
   }
 
   @Bean
-  public DefaultSecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  public JwtDecoder jwtDecoder() {
+    NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwksUri)
+        // Logto uses the ES384 algorithm to sign the JWTs by default.
+        .jwsAlgorithm(SignatureAlgorithm.ES384)
+        // The decoder should support the token type: Access Token + JWT.
+        .jwtProcessorCustomizer(customizer -> customizer.setJWSTypeVerifier(
+            new DefaultJOSEObjectTypeVerifier<SecurityContext>(new JOSEObjectType("at+jwt"))))
+        .build();
+
+    jwtDecoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(
+        new JwtIssuerValidator(issuer),
+        new JwtTimestampValidator()));
+
+    return jwtDecoder;
+  }
+
+  @Bean
+  @Order(1)
+  public DefaultSecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .securityMatcher("/api/**")
+        .oauth2ResourceServer(oauth2 -> oauth2
+            .jwt(Customizer.withDefaults()))
+        .authorizeHttpRequests(requests -> requests
+            .anyRequest().authenticated());
+
+    return http.build();
+  }
+
+  // Web page security configuration
+  @Bean
+  @Order(2)
+  public DefaultSecurityFilterChain webSecurityFilterChain(HttpSecurity http) throws Exception {
     http
         .authorizeHttpRequests(requests -> requests
-            .requestMatchers("/", "/home").permitAll()
-            .anyRequest().authenticated())
+            .requestMatchers("/user", "/token").authenticated()
+            .anyRequest().permitAll())
         .oauth2Login(oauth2 -> oauth2
             .authorizationEndpoint(authorization -> authorization.authorizationRequestResolver(
                 authorizationRequestResolver(this.clientRegistrationRepository)))
@@ -58,13 +111,13 @@ public class WebSecurityConfig {
   private Consumer<OAuth2AuthorizationRequest.Builder> authorizationRequestCustomizer() {
     return customizer -> customizer.additionalParameters(params -> {
       // Set the prompt parameter to "consent". User will be auto consent if Logto has
-      // a valid session
+      // a valid session. prompt=consent is required to obtain a refresh token
       params.put("prompt", "consent");
 
       // Set the prompt parameter to "login" to force the user to sign in every time
       // params.put("prompt", "login");
 
-      params.put("resource", "http://localhost:3001/api/test");
+      params.put("resource", audience);
     });
   }
 }

--- a/src/main/java/com/example/securingweb/WebSecurityConfig.java
+++ b/src/main/java/com/example/securingweb/WebSecurityConfig.java
@@ -63,6 +63,7 @@ public class WebSecurityConfig {
         .build();
 
     jwtDecoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(
+        new AudienceValidator(audience),
         new JwtIssuerValidator(issuer),
         new JwtTimestampValidator()));
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,8 @@ spring.security.oauth2.client.registration.logto.provider=logto
 spring.security.oauth2.client.provider.logto.issuer-uri=http://localhost:3001/oidc
 spring.security.oauth2.client.provider.logto.authorization-uri=http://localhost:3001/oidc/auth
 spring.security.oauth2.client.provider.logto.jwk-set-uri=http://localhost:3001/oidc/jwks
+
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:3001/oidc
+spring.security.oauth2.resourceserver.jwt.audiences=http://localhost:8080/api/protected
+spring.security.oauth2.resourceserver.jwt.jws-algorithms=ES348
+

--- a/src/main/resources/templates/token.html
+++ b/src/main/resources/templates/token.html
@@ -2,11 +2,11 @@
 <html>
 
 <head>
-  <title>token</title>
+  <title>tokens</title>
 </head>
 
 <body>
-  <h1>Refresh Token</h1>
+  <h1>Tokens</h1>
   <p><strong>refreshToken:</strong> <span th:text="${refreshToken}"></span></p>
   <br />
   <p><strong>accessToken:</strong> <span th:text="${accessToken}"></span> </p>


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use OAuth resource server to protect private APIs

- Define new AudienceValidtor to validate JWT token audience.
- Add new `apiSecurityFilterChain` for API path's security config. Use OAuth2.resourceServer to guard the API


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="1355" alt="image" src="https://github.com/logto-io/spring-boot-sample/assets/36393111/5eaa774a-e6d5-4a47-ad1e-3d5d3a902156">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
